### PR TITLE
Quiet option

### DIFF
--- a/bin/minigun
+++ b/bin/minigun
@@ -16,6 +16,7 @@ program
           'perform "insecure" TLS connections, for testing with' +
           'self-signed certificates')
   .option('-e, --environment <name>', 'Specify the environment to be used')
+  .option('-q, --quiet', 'Do not print anything to stdout')
   .action(commands.run);
 
 program
@@ -29,6 +30,7 @@ program
   .option('-k, --insecure', 'This  option explicitly allows Minigun to ' +
           'perform "insecure" TLS connections, for testing with' +
           'self-signed certificates')
+  .option('-q, --quiet', 'Do not print anything to stdout')
   .action(commands.quick);
 
 program
@@ -39,6 +41,7 @@ program
 program
   .command('dino')
   .description('Show dinosaur of the day')
+  .option('-q, --quiet', 'Do not print anything to stdout')
   .action(commands.dino);
 
 program.parse(process.argv);

--- a/lib/commands/dino.js
+++ b/lib/commands/dino.js
@@ -22,11 +22,16 @@ var dinos = [
 ];
 
 function dino(options) {
-  if (options.quiet) { return; }
-  console.log(
-' __________\n' +
-'< minigun! >\n' +
-' ----------\n' +
+  var balloon = !options.quiet ?
+    ' __________\n' +
+    '< minigun! >\n' +
+    ' ----------\n'
+  :
+    ' _______________________\n' +
+    '< You can\'t silence me! >\n' +
+    ' -----------------------\n';
+
+  console.log(balloon +
 '          \\\n' +
 '           \\');
   var i = _.random(0, dinos.length - 1);

--- a/lib/commands/dino.js
+++ b/lib/commands/dino.js
@@ -21,7 +21,8 @@ var dinos = [
 
 ];
 
-function dino() {
+function dino(options) {
+  if (options.quiet) { return; }
   console.log(
 ' __________\n' +
 '< minigun! >\n' +

--- a/lib/commands/quick.js
+++ b/lib/commands/quick.js
@@ -70,5 +70,5 @@ function quick(url, options) {
 
   fs.writeFileSync(tmpfn, JSON.stringify(script, null, 2), {flag: 'w'});
 
-  run(tmpfn, {});
+  run(tmpfn, {quiet: options.quiet});
 }

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -30,6 +30,11 @@ function run(scriptPath, options) {
     }
   }
 
+  function log() {
+    if (options.quiet) { return; }
+    console.log.apply(console, arguments);
+  }
+
   async.waterfall([
     function readScript(callback) {
 
@@ -51,7 +56,7 @@ function run(scriptPath, options) {
 
         var validation = core.validate(script);
         if (!validation.valid) {
-          console.log(validation.errors);
+          log(validation.errors);
           return callback(new Error('Test script validation error'), null);
         }
 
@@ -76,7 +81,7 @@ function run(scriptPath, options) {
         });
       } else {
         if (context.script.config.payload) {
-          console.log(
+          log(
             'WARNING: payload file not set, but payload is configured in %s\n',
             scriptPath);
         }
@@ -88,14 +93,14 @@ function run(scriptPath, options) {
     function(err, result) {
 
       if (err) {
-        console.log(err.message);
+        log(err.message);
         process.exit(1);
       }
 
       if (options.insecure) {
         if (result.script.config.tls) {
           if (result.script.config.tls.rejectUnauthorized) {
-            console.log('WARNING: TLS certificate validation enabled in the ' +
+            log('WARNING: TLS certificate validation enabled in the ' +
                         'test script, but explicitly disabled with ' +
                         '-k/--insecure.');
           }
@@ -109,17 +114,17 @@ function run(scriptPath, options) {
         environment: options.environment
       });
 
-      console.log('Log file: %s', logfile);
+      log('Log file: %s', logfile);
 
       //var bar;
       //var barTimer;
       ee.on('phaseStarted', function(opts) {
-        console.log(
+        log(
           'Phase %s%s started - duration: %ss',
           opts.index,
           (opts.name ? ' (' + opts.name + ')' : ''),
           opts.duration);
-        if (tty.isatty(process.stdout)) {
+        if (!options.quiet && tty.isatty(process.stdout)) {
           cli.spinner('');
         }
         // bar = new ProgressBar('[ :bar ]', {
@@ -135,35 +140,40 @@ function run(scriptPath, options) {
       ee.on('phaseCompleted', function(opts) {
 
         //clearInterval(barTimer);
-        if (tty.isatty(process.stdout)) {
+        if (!options.quiet && tty.isatty(process.stdout)) {
           cli.spinner('', true);
         }
-        console.log(
+        log(
           'phase %s%s completed',
           opts.index,
           (opts.name ? ' (' + opts.name + ')' : ''));
       });
 
       ee.on('stats', function(report) {
-        if (tty.isatty(process.stdout)) {
+        if (!options.quiet && tty.isatty(process.stdout)) {
           cli.spinner('', true);
         }
 
-        console.log('Intermediate report @ %s', report.timestamp);
-        humanize(report);
+        log('Intermediate report @ %s', report.timestamp);
+        if (!options.quiet) {
+          humanize(report);
+        }
 
-        if (tty.isatty(process.stdout)) {
+        if (!options.quiet && tty.isatty(process.stdout)) {
           cli.spinner('');
         }
       });
 
       ee.once('done', function(report) {
+        if (!options.quiet && tty.isatty(process.stdout)) {
+          cli.spinner('', true);
+        }
 
-        cli.spinner('', true);
-
-        console.log('all scenarios completed');
-        console.log('Complete report @ %s', report.aggregate.timestamp);
-        humanize(report.aggregate);
+        log('all scenarios completed');
+        log('Complete report @ %s', report.aggregate.timestamp);
+        if (!options.quiet) {
+          humanize(report.aggregate);
+        }
 
         fs.writeFileSync(logfile, JSON.stringify(report, null, 2), {flag: 'w'});
 
@@ -177,9 +187,9 @@ function run(scriptPath, options) {
                 var msg = util.format(
                   'ensure condition failed: ensure.%s < %s', bucket, max);
                 if (tty.isatty(process.stdout)) {
-                  console.log(msg);
+                  log(msg);
                 } else {
-                  console.log(msg);
+                  log(msg);
                 }
                 process.exit(1);
               }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "eslint": "^0.21.2",
     "istanbul": "^0.3.14",
+    "jscs": "^2.3.0",
     "pre-commit": "^1.0.7",
     "tape": "^4.0.0"
   },


### PR DESCRIPTION
This came up while @xicombd was writing something using minigun.

It is unshibelike to not say anything, but this PR adds the `--quiet`/`-q` option to the command line, which can also be passed through javascript.

Although it might not be so useful on the command line, scripts using minigun as a library will want to stop it from writing to stdout.