### PR TITLE
Support yaml

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -4,11 +4,13 @@ const _ = require('lodash');
 const core = require('minigun-core');
 const runner = core.runner;
 const fs = require('fs');
+const path = require('path');
 const async = require('async');
 const csv = require('csv-parse');
 const tty = require('tty');
 const util = require('util');
 const cli = require('cli');
+const YAML = require('yamljs');
 
 module.exports = run;
 
@@ -47,7 +49,11 @@ function run(scriptPath, options) {
 
         let script;
         try {
-          script = JSON.parse(data);
+          if (/\.ya?ml$/.test(path.extname(scriptPath))) {
+            script = YAML.parse(data);
+          } else {
+            script = JSON.parse(data);
+          }
         } catch (e) {
           const msg2 = util.format(
             'File %s does not appear to be valid JSON', scriptPath);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "debug": "^2.2.0",
     "lodash": "^3.9.1",
     "minigun-core": "latest",
-    "open": "0.0.5"
+    "open": "0.0.5",
+    "yamljs": "^0.2.4"
   },
   "devDependencies": {
     "eslint": "^0.21.2",


### PR DESCRIPTION



Why this:

```json
{
  "config": {
      "target": "http://127.0.0.1:3000",
      "phases": [
        { "duration": 120, "arrivalRate": 10 }
      ],
      "defaults": {
        "headers": {
          "content-type": "application/json",
          "x-my-service-auth": "987401838271002188298567"
        }
      }
  },
  "scenarios": [
    {
      "flow": [
        { "get": {"url": "/test"}}
      ]
    }
  ]
}
```

If you can have this:

```yml
config:
  target: 'http://127.0.0.1:3000'
  phases: 
    - duration: 120
      arrivalRate: 10
  defaults: 
    headers: 
      content-type: application/json
      x-my-service-auth: '987401838271002188298567'

scenarios:
  - flow:
    - get:
        url: "/test"
```

> Some people can't type more than three double quotes per minute
>
> -- <cite>Winston S. Churchill</cite>


![](http://i.giphy.com/stiMEtNPKl9hC.gif)
