### PR TITLE
Recommend wrk instead of ab for http testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ testing of applications and APIs with complex transactional scenarios.
 
 Having said that, Minigun is capable of generating 500+ RPS on modest hardware
 (a 512MB Digital Ocean droplet). Still though, if you are after raw RPS to
-simply hammer a single URL, you may want to use `ab` instead.
+simply hammer a single URL, you may want to use [`wrk`](https://github.com/wg/wrk) instead.
 
 **tldr:**
-Benchmarking an Nginx installation? Use `ab`. Testing a Node.js
+Benchmarking an Nginx installation? Use [`wrk`](https://github.com/wg/wrk). Testing a Node.js
 API, a RoR webapp, or a realtime WebSocket-based app? Use Minigun.
 
 # Design


### PR DESCRIPTION
ab is old, single threaded and very basic, wrk allows some basic lua scripting as well and I find it much more stable. 

`ab` also has the issue that on certain OS X installations it is broken.