### PR TITLE
Remove duplicated key from .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,6 @@
     "no-unused-expressions": 1,
     "no-native-reassign": 1,
     "no-fallthrough": 1,
-    "handle-callback-err": 1,
     "camelcase": 1,
     "no-unused-vars": 1,
 


### PR DESCRIPTION
It was making `npm run is_linted` fail:

```
➜  minigun git:(master) npm run is_linted

> minigun@1.3.2 is_linted /Users/xicombd/Code/minigun/minigun
> find . -name '*.js' | grep -v node_modules | grep -v coverage | xargs eslint


/Users/xicombd/Code/minigun/minigun/node_modules/eslint/lib/config.js:76
                throw e;
                ^
YAMLException: Cannot read config file: /Users/xicombd/Code/minigun/minigun/.eslintrc
Error: duplicated mapping key at line 35, column 29:
        "handle-callback-err": 2,
                                ^
```