### PR TITLE
Addition of phase information to reports

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -214,6 +214,8 @@ function run(scriptPath, options) {
           humanize(report.aggregate);
         }
 
+        report.phases = _.get(result, 'script.config.phases', []);
+
         fs.writeFileSync(logfile, JSON.stringify(report, null, 2), {flag: 'w'});
 
         if (result.script.config.ensure) {

--- a/lib/report/index.html.ejs
+++ b/lib/report/index.html.ejs
@@ -199,18 +199,10 @@ var markers = [];
 if(l.size(Report.phases) > 0) {
   markers = l.foldl(Report.phases, function(acc, phase, index) {
     var label = phase.label || 'Phase ' + (index + 1);
-
-    if(index === 0) {
-      acc.push({
-        timestamp: 0,
-        label: label
-      });
-
-      return acc;
-    }
+    var timestamp = (index === 0) ? 0 : Report.phases[index - 1].duration + acc[index - 1].timestamp;
 
     acc.push({
-      timestamp: Report.phases[index - 1].duration + acc[index - 1].timestamp,
+      timestamp: timestamp,
       label: label
     });
 

--- a/lib/report/index.html.ejs
+++ b/lib/report/index.html.ejs
@@ -195,6 +195,29 @@ $('#testDuration').html(l.size(Report.intermediate) * 10);
 $('#scenariosCompleted').html(Report.aggregate.scenariosCompleted);
 $('#scenariosCreated').html(Report.aggregate.scenariosCreated);
 
+var markers = [];
+if(l.size(Report.phases) > 0) {
+  markers = l.foldl(Report.phases, function(acc, phase, index) {
+    var label = phase.label || 'Phase ' + (index + 1);
+
+    if(index === 0) {
+      acc.push({
+        timestamp: 0,
+        label: label
+      });
+
+      return acc;
+    }
+
+    acc.push({
+      timestamp: Report.phases[index - 1].duration + acc[index - 1].timestamp,
+      label: label
+    });
+
+    return acc;
+  }, []);
+}
+
 if (l.size(Report.aggregate.codes) > 0) {
   l.each(Report.aggregate.codes, function(count, code) {
     var anchor = '';
@@ -304,7 +327,8 @@ if (l.size(Report.aggregate.codes) > 0) {
     legend: uniqueCodes,
     right: 50,
     chart_type: 'line',
-    area: false
+    area: false,
+    markers: markers
   });
 }
 
@@ -338,9 +362,9 @@ if (l.size(Report.aggregate.errors) > 0) {
     data: errorData,
     x_accessor: 'timestamp',
     y_accessor: uniqueErrors,
-
     chart_type: 'line',
-    area: false
+    area: false,
+    markers: markers
   });
 
 }
@@ -366,7 +390,8 @@ MG.data_graphic({
   right: 50,
   interpolate: 'monotone',
   mouseover: function(d, i) {
-  }
+  },
+  markers: markers
 });
 
 // MG.data_graphic({
@@ -403,7 +428,8 @@ MG.data_graphic({
   target: '.rps-mean',
   x_accessor: 'timestamp',
   y_accessor: ['rpsMean'],
-  interpolate: 'monotone'
+  interpolate: 'monotone',
+  markers: markers
 });
 
 MG.data_graphic({
@@ -417,7 +443,8 @@ MG.data_graphic({
   target: '.rps-count',
   x_accessor: 'timestamp',
   y_accessor: ['rpsCount'],
-  interpolate: 'monotone'
+  interpolate: 'monotone',
+  markers: markers
 });
 </script>
 <div id="footer">


### PR DESCRIPTION
Relates to #34 

Adds markers to each time based graph at the beginning of each phase. Labels are defined in the config, e.g.

```json
{
  "config": {
    "target": "http://localhost:3000",
    "phases": [{
      "duration": 20,
      "arrivalRate": 10,
      "label": "ramp 10"
    },
    {
      "duration": 20,
      "arrivalRate": 20,
      "label": "ramp 20"
    }],
    "defaults": {}
  },
  "scenarios": [{
    "flow": [{
      "get": {
        "url": "/"
      }
    }]
  }]
}
```

Phases that aren't marked with a label get annotated with the phase number, e.g. 'Phase 1', 'Phase 2' etc.

<img width="362" alt="screen shot 2016-01-18 at 22 15 36" src="https://cloud.githubusercontent.com/assets/5588391/12404294/24532090-be32-11e5-84c9-785090c131ee.png">
