### PR TITLE
Use phase 'name' key instead of 'label'

### DIFF
--- a/lib/report/index.html.ejs
+++ b/lib/report/index.html.ejs
@@ -198,7 +198,7 @@ $('#scenariosCreated').html(Report.aggregate.scenariosCreated);
 var markers = [];
 if(l.size(Report.phases) > 0) {
   markers = l.foldl(Report.phases, function(acc, phase, index) {
-    var label = phase.label || 'Phase ' + (index + 1);
+    var label = phase.name || 'Phase ' + (index + 1);
     var timestamp = (index === 0) ? 0 : Report.phases[index - 1].duration + acc[index - 1].timestamp;
 
     acc.push({


### PR DESCRIPTION
As requested in #41, uses `name` instead of `label`